### PR TITLE
Refactor | eol_utils.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tools/workflow-engine/charms/temporal-worker/dist
 *.tfvars*
 .vscode
 venv
+# Add Hidden venv
+.venv

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -34,10 +34,15 @@ def is_track_eol(track_value: dict[str, str], track_name: str | None = None) -> 
     Returns:
         bool: True if the track is EOL, False otherwise.
     """
-    eol_date = datetime.strptime(
-        track_value["end-of-life"],
-        "%Y-%m-%dT%H:%M:%SZ",
-    ).replace(tzinfo=timezone.utc)
+    eol_str = track_value.get('end-of-life')
+
+    # Handle situations where EOL is not populated, and assumes that it is EOL
+    # This might never happen, but it's a simple check
+    if eol_str is None:
+        logger.error(f"No EOL provided for {track_name or 'UNNAMED TRACK'}! Assuming EOL is now")
+        return True
+    
+    eol_date = datetime.strptime(eol_str, EOL_TRACK_FMT).replace(tzinfo=timezone.utc)
     is_eol = eol_date < datetime.now(timezone.utc)
 
     if is_eol and track_name is not None:

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -20,7 +20,7 @@ EOL_DISTRO_FMT = "%Y-%m-%d"
 
 VERSIONS = [
     version.strip().split(',')[0]
-    for version in Path(UBUNTU_DISTRO_INFO).open(encoding='UTF-8').readlines()[1::]
+    for version in Path(UBUNTU_DISTRO_INFO).open(encoding='UTF-8').readlines()[1:]
 ]
 
 logger = get_logger()

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -129,6 +129,7 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
     """
     _, base_version_id = base.split(':') if base is not None else track.split("-")
 
+    # Should this raise an Exception? Currently it has the same behavior as a valid EOL
     if not any(version.startswith(base_version_id) for version in VERSIONS):
         logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")
         return None

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -1,4 +1,3 @@
-import re
 from datetime import (
     datetime, 
     timezone,
@@ -6,7 +5,6 @@ from datetime import (
 from pathlib import Path
 from typing import (
     Any, 
-    Optional, 
     Literal,
 )
 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -83,7 +83,7 @@ def get_base_eol(base: str, eol_target: Literal['eol', 'eol-server', 'eol-esm'] 
     eol_date = datetime.strptime(distro[eol_target], EOL_DISTRO_FMT).replace(tzinfo=timezone.utc)
     return eol_date
 
-def generate_base_eol_exceed_warning(tracks_eol_exceed_base_eol: list[dict[str, Any]]):
+def generate_base_eol_exceed_warning(tracks_eol_exceed_base_eol: list[dict[str, Any]]) -> tuple[str, str]:
     """Generates markdown table for the tracks that exceed the base image EOL date.
 
     Args:
@@ -92,15 +92,22 @@ def generate_base_eol_exceed_warning(tracks_eol_exceed_base_eol: list[dict[str, 
     Returns:
         tuple: A tuple containing the title and text for the warning.
     """
-    title = "Found tracks with EOL date exceeding base image's EOL date\n"
-    text = "Following tracks have an EOL date that exceeds the base image's EOL date:\n"
-    table = "| Track | Base | Track EOL Date | Base EOL Date |\n"
-    table += "|-------|------|----------------|---------------|\n"
-    for build in tracks_eol_exceed_base_eol:
-        table += f"| {build['track']} | {build['base']} | {build['track_eol']} | {build['base_eol']} |\n"
-    text += table
-    text += "\nPlease check the EOL date of the base image and the track.\n"
-    return title, text
+    
+    # Set up lazy record generator
+    table_records = (
+        f"| {build['track']} | {build['base']} | {build['track_eol']} | {build['base_eol']} |" 
+        for build in tracks_eol_exceed_base_eol
+    )
+
+    title = "Found tracks with EOL date exceeding base image's EOL date"
+
+    # Build body text using implicit string joining
+    body = ("Following tracks have an EOL date that exceeds the base image's EOL date:\n"
+            "| Track | Base | Track EOL Date | Base EOL Date |\n"
+            "|-------|------|----------------|---------------|\n"
+            f"{'\n'.join(table_records)}" # Insert records
+            "\nPlease check the EOL date of the base image and the track.\n")
+    return title, body
 
 
 def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = None) -> Optional[dict[str, Any]]:

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -9,6 +9,12 @@ from ...shared.logs import get_logger
 UBUNTU_DISTRO_INFO = "/usr/share/distro-info/ubuntu.csv"
 VERSION_ID_REGEX = re.compile(r"^(\d{1,2}\.\d{1,2})$")
 
+# Track EOL strfmt
+EOL_TRACK_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+# Distro Info strfmt
+EOL_DISTRO_FMT = "%Y-%m-%d"
+
 logger = get_logger()
 
 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -129,8 +129,6 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
     """
     _, base_version_id = base.split(':') if base is not None else track.split("-")
 
-    # Should this raise an Exception? Currently it has the same behavior as a valid EOL
-
     # NOTE: str.startswith() is used to avoid rstripping 'LTS' from 'LTS' releases
     if not any(version.startswith(base_version_id) for version in VERSIONS):
         logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -128,6 +128,8 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
     _, base_version_id = base.split(':') if base is not None else track.split("-")
 
     # Should this raise an Exception? Currently it has the same behavior as a valid EOL
+
+    # NOTE: str.startswith() is used to avoid rstripping 'LTS' from 'LTS' releases
     if not any(version.startswith(base_version_id) for version in VERSIONS):
         logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")
         return None

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -114,7 +114,7 @@ def generate_base_eol_exceed_warning(tracks_eol_exceed_base_eol: list[dict[str, 
     return title, body
 
 
-def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = None) -> Optional[dict[str, Any]]:
+def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = None) -> dict[str, Any] | None:
     """Check if the track EOL date exceeds the base image EOL date.
 
     Args:
@@ -123,8 +123,9 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
         base (str | None): The base image name, e.g., "ubuntu:22.04". If None, the base will be inferred from the track name.
 
     Returns:
-        Optional[dict[str, Any]]: Dictionary containing the track name, base image, EOL date, and base image EOL date if the track EOL exceeds the base image EOL date.
-        None: If the track EOL date does not exceed the base image EOL date.
+        (dict[str, Any] | None): Dictionary containing the track name, base image, EOL date, and base image EOL date if the track EOL exceeds the base image EOL date.
+
+        (None): If the track EOL date does not exceed the base image EOL date.
     """
     if not base:
         _, base_version_id = track.split("-")

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -125,10 +125,7 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
         base_version_id = base.split(":")[-1]
 
     base_eol = get_base_eol(base_version_id)
-    eol_date = datetime.strptime(
-        track_eol,
-        "%Y-%m-%dT%H:%M:%SZ",
-    ).replace(tzinfo=timezone.utc)
+    eol_date = datetime.strptime(track_eol,EOL_TRACK_FMT).replace(tzinfo=timezone.utc)
 
     if eol_date > base_eol:
         logger.warning(
@@ -138,8 +135,8 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
         return {
             "track": track,
             "base": f"ubuntu:{base_version_id}",
-            "track_eol": eol_date.strftime("%Y-%m-%d"),
-            "base_eol": base_eol.strftime("%Y-%m-%d"),
+            "track_eol": eol_date.strftime(EOL_DISTRO_FMT),
+            "base_eol": base_eol.strftime(EOL_DISTRO_FMT),
         }
 
     return None

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -25,11 +25,11 @@ EOL_DISTRO_FMT = "%Y-%m-%d"
 logger = get_logger()
 
 
-def is_track_eol(track_value: str, track_name: str | None = None) -> bool:
+def is_track_eol(track_value: dict[str, str], track_name: str | None = None) -> bool:
     """Test if track is EOL, or still valid. Log warning if track_name is provided.
 
     Args:
-        track_value (str): The value of the track, a dictionary containing 'end-of-life'.
+        track_value (dict[str, str]): The value of the track, a dictionary containing 'end-of-life' and a iso timestamp.
         track_name (str | None): The name of the track. Defaults to None.
     Returns:
         bool: True if the track is EOL, False otherwise.

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -44,8 +44,8 @@ def is_track_eol(track_value: dict[str, str], track_name: str | None = None) -> 
     eol_date = datetime.strptime(eol_str, EOL_TRACK_FMT).replace(tzinfo=timezone.utc)
     is_eol = eol_date < datetime.now(timezone.utc)
 
-    if is_eol and track_name is not None:
-        logger.warning(f'Removing EOL track "{track_name}", EOL: {eol_date}')
+    if is_eol:
+        logger.warning(f'Removing EOL track "{track_name or 'UNKNOWN TRACK'}", EOL: {eol_date}')
 
     return is_eol
 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -51,11 +51,12 @@ def is_track_eol(track_value: dict[str, str], track_name: str | None = None) -> 
     return is_eol
 
 
-def get_base_eol(base: str) -> datetime:
+def get_base_eol(base: str, eol_target: Literal['eol', 'eol-server', 'eol-esm'] = 'eol') -> datetime:
     """Find the EOL of the Ubuntu base image by reading /usr/share/distro-info/ubuntu.csv.
 
     Args:
         base (str): The version ID of the base image, e.g., "22.04".
+        eol_target (Literal['eol', 'eol-server', 'eol-esm']): The EOL target to get (default 'eol')
     Returns:
         datetime: The end-of-life date of the base image.
     Raises:

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -13,13 +13,17 @@ from typing import (
 from ...shared.logs import get_logger
 
 UBUNTU_DISTRO_INFO = "/usr/share/distro-info/ubuntu.csv"
-VERSION_ID_REGEX = re.compile(r"^(\d{1,2}\.\d{1,2})$")
 
 # Track EOL strfmt
 EOL_TRACK_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 # Distro Info strfmt
 EOL_DISTRO_FMT = "%Y-%m-%d"
+
+VERSIONS = [
+    version.strip().split(',')[0]
+    for version in Path(UBUNTU_DISTRO_INFO).open(encoding='UTF-8').readlines()[1::]
+]
 
 logger = get_logger()
 
@@ -124,7 +128,7 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
     """
     if not base:
         _, base_version_id = track.split("-")
-        if not VERSION_ID_REGEX.match(base_version_id):
+        if not any(version.startswith(base_version_id) for version in VERSIONS):
             logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")
             return None
     else:

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -123,7 +123,7 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
         None: If the track EOL date does not exceed the base image EOL date.
     """
     if not base:
-        base_version_id = track.split("-")[-1]
+        _, base_version_id = track.split("-")
         if not VERSION_ID_REGEX.match(base_version_id):
             logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")
             return None

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -45,9 +45,10 @@ def is_track_eol(track_value: dict[str, str], track_name: str | None = None) -> 
     
     eol_date = datetime.strptime(eol_str, EOL_TRACK_FMT).replace(tzinfo=timezone.utc)
     is_eol = eol_date < datetime.now(timezone.utc)
-
+    
+    unknown = 'UNKNOWN TRACK'
     if is_eol:
-        logger.warning(f'Removing EOL track "{track_name or 'UNKNOWN TRACK'}", EOL: {eol_date}')
+        logger.warning(f'Removing EOL track "{track_name or unknown}", EOL: {eol_date}')
 
     return is_eol
 
@@ -103,11 +104,12 @@ def generate_base_eol_exceed_warning(tracks_eol_exceed_base_eol: list[dict[str, 
 
     title = "Found tracks with EOL date exceeding base image's EOL date"
 
+    newline = '\n'
     # Build body text using implicit string joining
     body = ("Following tracks have an EOL date that exceeds the base image's EOL date:\n"
             "| Track | Base | Track EOL Date | Base EOL Date |\n"
             "|-------|------|----------------|---------------|\n"
-            f"{'\n'.join(table_records)}" # Insert records
+            f"{newline.join(table_records)}" # Insert records
             "\nPlease check the EOL date of the base image and the track.\n")
     return title, body
 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -1,4 +1,3 @@
-import csv
 import re
 from datetime import (
     datetime, 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -127,14 +127,12 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
 
         (None): If the track EOL date does not exceed the base image EOL date.
     """
-    if not base:
-        _, base_version_id = track.split("-")
-        if not any(version.startswith(base_version_id) for version in VERSIONS):
-            logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")
-            return None
-    else:
-        base_version_id = base.split(":")[-1]
+    _, base_version_id = base.split(':') if base is not None else track.split("-")
 
+    if not any(version.startswith(base_version_id) for version in VERSIONS):
+        logger.warning(f"Track-base-EOL validation skipped for aliased track {track}")
+        return None
+    
     base_eol = get_base_eol(base_version_id)
     eol_date = datetime.strptime(track_eol,EOL_TRACK_FMT).replace(tzinfo=timezone.utc)
 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -1,8 +1,15 @@
 import csv
 import re
-from datetime import datetime, timezone
+from datetime import (
+    datetime, 
+    timezone,
+)
 from pathlib import Path
-from typing import Any, Optional
+from typing import (
+    Any, 
+    Optional, 
+    Literal,
+)
 
 from ...shared.logs import get_logger
 

--- a/src/image/utils/eol_utils.py
+++ b/src/image/utils/eol_utils.py
@@ -136,16 +136,14 @@ def track_eol_exceeds_base_eol(track: str, track_eol: str, base: str | None = No
     base_eol = get_base_eol(base_version_id)
     eol_date = datetime.strptime(track_eol,EOL_TRACK_FMT).replace(tzinfo=timezone.utc)
 
-    if eol_date > base_eol:
-        logger.warning(
-            f"Track {track} has an EOL date {eol_date} that exceeds the base image EOL date {base_eol}"
-        )
+    # Early return for happy path
+    if eol_date < base_eol:
+        return None
 
-        return {
-            "track": track,
-            "base": f"ubuntu:{base_version_id}",
-            "track_eol": eol_date.strftime(EOL_DISTRO_FMT),
-            "base_eol": base_eol.strftime(EOL_DISTRO_FMT),
-        }
-
-    return None
+    logger.warning(f"Track {track} has an EOL date {eol_date} that exceeds the base image EOL date {base_eol}")
+    return {
+        "track": track,
+        "base": f"ubuntu:{base_version_id}",
+        "track_eol": eol_date.strftime(EOL_DISTRO_FMT),
+        "base_eol": base_eol.strftime(EOL_DISTRO_FMT),
+    }


### PR DESCRIPTION
Some totally unnecessary refactoring of a utility module.

# Overview
 - Reduced the number of imported modules (removed `re` and `csv`), used `pathlib` and the `Path().open()` syntax instead
     - Also use a list comprehension when consuming the `.open()` generator to build a `{version: EOL}` dictionary for fast lookup of version eol dates 
 - Pre-cache the valid version numbers on module import under the `VERSIONS` global (this allows for more accurate base image checks vs just checking that the base image is `\d{1,2}.\d{1,2}`.
 - Move `datetime` string formatting definitions out of hardcode and into globals `EOL_DISTRO_FMT` and `EOL_TRACK_FMT`
     - This should make it easier to change later if necessary, or set using an environment variable.
- Use `dict.get()` to pull keys from provided dictionaries and add `is None` checks to prevent invalid json from causing issues
- Reduce number of string concatenations in `track_eol_exceeds_base_eol` function and use implicit string concatenation instead.
- Use `str.startswith()` instead of `str.rstrip('LTS').strip()` to make it clear that we're checking for the version number at the beginning of the string (I just think it's more readable this way)
- Invert some conditionals and use early returns instead of `else` to flatten the code a bit. 
- Fix a few incorrect type hints (`track_value` was marked as `str` and is accessed as a `dict` in the body of `is_track_eol`)


# Requests
I have added comments throughout the code in places where business logic has changed or a new possible state can be reached (some hard fails are now caught). I would want to approach these changes with the ROCKS team to make sure that no existing systems are expecting the un-handled behavior of this module.

# Post Script
Thanks to anyone who actually looks at this. I just did this in a couple hours for fun. Love trying to re-factor code in this way.